### PR TITLE
Add kubeadm_opts to variables

### DIFF
--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -6,6 +6,11 @@ token: b0f7b8.8d1767876297d85c
 # 1.8.x feature: --feature-gates SelfHosting=true
 init_opts: ""
 
+# Any other additional opts you want to add.. 
+kubeadm_opts: ""
+# For example:
+# kubeadm_opts: '--apiserver-cert-extra-sans "k8s.domain.com,kubernetes.domain.com"'
+
 service_subnet: 10.96.0
 service_cidr: "{{ service_subnet }}.0/12"
 dns_name: cluster.local

--- a/roles/kubernetes/master/tasks/main.yml
+++ b/roles/kubernetes/master/tasks/main.yml
@@ -12,6 +12,7 @@
                  --pod-network-cidr {{ pod_network_cidr }} \
                  --apiserver-advertise-address {{ groups['master'][0] }} \
                  --token {{ token }} \
+                 {{ kubeadm_opts }} \
                  {{ init_opts }}
   register: init_cluster
 


### PR DESCRIPTION
I needed the ability to specify my domain name in order to setup remote
access, so I added kubeadm_opts to this Ansible playbook.

This allows someone to modify the kubeadm options so you may add /
append domain names.