### PR TITLE
Removes RBAC, add support for Debian

### DIFF
--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -6,6 +6,11 @@ token: b0f7b8.8d1767876297d85c
 # 1.8.x feature: --feature-gates SelfHosting=true
 init_opts: ""
 
+# Any other additional opts you want to add.. 
+kubeadm_opts: ""
+# For example:
+# kubeadm_opts: '--apiserver-cert-extra-sans "k8s.domain.com,kubernetes.domain.com"'
+
 service_subnet: 10.96.0
 service_cidr: "{{ service_subnet }}.0/12"
 dns_name: cluster.local

--- a/roles/cni/defaults/main.yml
+++ b/roles/cni/defaults/main.yml
@@ -4,9 +4,7 @@ flannel:
   name: flannel
   template:
     ds: flannel.yml
-    rbac: flannel-rbac.yml
 calico:
   name: calico
   template:
     ds: calico.yml
-    rbac: calico-rbac.yml

--- a/roles/cni/tasks/main.yml
+++ b/roles/cni/tasks/main.yml
@@ -7,29 +7,8 @@
 - name: Create Kubernetes addon directory
   file: path={{ network_dir }} state=directory
 
-- name: "Copy {{ cni.name }} RBAC yml file"
-  template: src="{{ cni.template.rbac }}.j2" dest={{ network_dir }}/{{ cni.template.rbac }}
-
 - name: "Copy {{ cni.name }} yml file"
   template: src="{{ cni.template.ds }}.j2" dest={{ network_dir }}/{{ cni.template.ds }}
-
-- name: "Check {{ cni.name }} cluster role already exists"
-  shell: |
-    kubectl --kubeconfig={{ kubeadmin_config }} \
-            get clusterrole | grep {{ cni.name }}
-  delegate_to: "{{ groups['master'][0] }}"
-  run_once: true
-  register: check_role
-  ignore_errors: true
-
-- name: "Create {{ cni.name }} cluster role"
-  when: check_role|failed
-  shell: |
-    kubectl create --kubeconfig={{ kubeadmin_config }} \
-                   -f {{ network_dir }}/{{ cni.template.rbac }}
-  delegate_to: "{{ groups['master'][0] }}"
-  run_once: true
-  register: create_role
 
 - name: "Check {{ cni.name }} daemonset is working"
   shell: |

--- a/roles/cni/templates/calico.yml.j2
+++ b/roles/cni/templates/calico.yml.j2
@@ -1,30 +1,33 @@
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: calico-policy-controller
-  namespace: kube-system
----
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: calico-cni-plugin
-  namespace: kube-system
----
+# Calico Version v2.6.5
+# https://docs.projectcalico.org/v2.6/releases#v2.6.5
+# This manifest includes the following component versions:
+#   calico/node:v2.6.5
+#   calico/cni:v1.11.2
+#   calico/kube-controllers:v1.0.2
+
+# This ConfigMap is used to configure a self-hosted Calico installation.
 kind: ConfigMap
 apiVersion: v1
 metadata:
   name: calico-config
   namespace: kube-system
 data:
+  # The location of your etcd cluster.  This uses the Service clusterIP
+  # defined below.
   etcd_endpoints: "http://10.96.232.136:6666"
+
+  # Configure the Calico backend to use.
   calico_backend: "bird"
+
+  # The CNI network configuration to install on each node.
   cni_network_config: |-
     {
-        "name": "cbr0",
+        "name": "k8s-pod-network",
         "cniVersion": "0.1.0",
         "type": "calico",
         "etcd_endpoints": "__ETCD_ENDPOINTS__",
         "log_level": "info",
+        "mtu": 1500,
         "ipam": {
             "type": "calico-ipam"
         },
@@ -37,7 +40,12 @@ data:
             "kubeconfig": "/etc/cni/net.d/__KUBECONFIG_FILENAME__"
         }
     }
+
 ---
+
+# This manifest installs the Calico etcd on the kubeadm master.  This uses a DaemonSet
+# to force it to run on the master even when the master isn't schedulable, and uses
+# nodeSelector to ensure it only runs on the master.
 apiVersion: extensions/v1beta1
 kind: DaemonSet
 metadata:
@@ -51,11 +59,22 @@ spec:
       labels:
         k8s-app: calico-etcd
       annotations:
+        # Mark this pod as a critical add-on; when enabled, the critical add-on scheduler
+        # reserves resources for critical add-on pods so that they can be rescheduled after
+        # a failure.  This annotation works in tandem with the toleration below.
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
+      # Only run this pod on the master.
       tolerations:
+      # this taint is set by all kubelets running `--cloud-provider=external`
+      # so we should tolerate it to schedule the calico pods
+      - key: node.cloudprovider.kubernetes.io/uninitialized
+        value: "true"
+        effect: NoSchedule
       - key: node-role.kubernetes.io/master
         effect: NoSchedule
+      # Allow this pod to be rescheduled while the node is in "critical add-ons only" mode.
+      # This, along with the annotation above marks this pod as a critical add-on.
       - key: CriticalAddonsOnly
         operator: Exists
       nodeSelector:
@@ -78,7 +97,11 @@ spec:
         - name: var-etcd
           hostPath:
             path: /var/etcd
+
 ---
+
+# This manifest installs the Service which gets traffic to the Calico
+# etcd.
 apiVersion: v1
 kind: Service
 metadata:
@@ -87,12 +110,20 @@ metadata:
   name: calico-etcd
   namespace: kube-system
 spec:
+  # Select the calico-etcd pod running on the master.
   selector:
     k8s-app: calico-etcd
+  # This ClusterIP needs to be known in advance, since we cannot rely
+  # on DNS to get access to etcd.
   clusterIP: 10.96.232.136
   ports:
     - port: 6666
+
 ---
+
+# This manifest installs the calico/node container, as well
+# as the Calico CNI plugins and network config on
+# each master and worker node in a Kubernetes cluster.
 kind: DaemonSet
 apiVersion: extensions/v1beta1
 metadata:
@@ -109,52 +140,97 @@ spec:
       labels:
         k8s-app: calico-node
       annotations:
+        # Mark this pod as a critical add-on; when enabled, the critical add-on scheduler
+        # reserves resources for critical add-on pods so that they can be rescheduled after
+        # a failure.  This annotation works in tandem with the toleration below.
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
       hostNetwork: true
       tolerations:
+      # this taint is set by all kubelets running `--cloud-provider=external`
+      # so we should tolerate it to schedule the calico pods
+      - key: node.cloudprovider.kubernetes.io/uninitialized
+        value: "true"
+        effect: NoSchedule
       - key: node-role.kubernetes.io/master
         effect: NoSchedule
+      # Allow this pod to be rescheduled while the node is in "critical add-ons only" mode.
+      # This, along with the annotation above marks this pod as a critical add-on.
       - key: CriticalAddonsOnly
         operator: Exists
       serviceAccountName: calico-cni-plugin
+      # Minimize downtime during a rolling upgrade or deletion; tell Kubernetes to do a "force
+      # deletion": https://kubernetes.io/docs/concepts/workloads/pods/pod/#termination-of-pods.
+      terminationGracePeriodSeconds: 0
       containers:
+        # Runs calico/node container on each Kubernetes node.  This
+        # container programs network policy and routes on each
+        # host.
         - name: calico-node
-          image: quay.io/calico/node:v2.5.1
+          image: quay.io/calico/node:v2.6.5
           env:
+            # The location of the Calico etcd cluster.
             - name: ETCD_ENDPOINTS
               valueFrom:
                 configMapKeyRef:
                   name: calico-config
                   key: etcd_endpoints
+            # Enable BGP.  Disable to enforce policy only.
             - name: CALICO_NETWORKING_BACKEND
               valueFrom:
                 configMapKeyRef:
                   name: calico-config
                   key: calico_backend
+            # Cluster type to identify the deployment type
+            - name: CLUSTER_TYPE
+              value: "kubeadm,bgp"
+            # Set noderef for node controller.
+            - name: CALICO_K8S_NODE_REF
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            # Disable file logging so `kubectl logs` works.
             - name: CALICO_DISABLE_FILE_LOGGING
               value: "true"
+            # Set Felix endpoint to host default action to ACCEPT.
             - name: FELIX_DEFAULTENDPOINTTOHOSTACTION
               value: "ACCEPT"
+            # Configure the IP Pool from which Pod IPs will be chosen.
             - name: CALICO_IPV4POOL_CIDR
-              value: "{{ pod_network_cidr }}"
+              value: "192.168.0.0/16"
             - name: CALICO_IPV4POOL_IPIP
               value: "always"
+            # Disable IPv6 on Kubernetes.
             - name: FELIX_IPV6SUPPORT
               value: "false"
+            # Set MTU for tunnel device used if ipip is enabled
+            - name: FELIX_IPINIPMTU
+              value: "1440"
+            # Set Felix logging to "info"
             - name: FELIX_LOGSEVERITYSCREEN
               value: "info"
+            # Auto-detect the BGP IP address.
             - name: IP
               value: ""
-            - name: IP_AUTODETECTION_METHOD
-              value: "{{ cni_opts }}"
-            - name: IP6_AUTODETECTION_METHOD
-              value: "{{ cni_opts }}"
+            - name: FELIX_HEALTHENABLED
+              value: "true"
           securityContext:
             privileged: true
           resources:
             requests:
               cpu: 250m
+          livenessProbe:
+            httpGet:
+              path: /liveness
+              port: 9099
+            periodSeconds: 10
+            initialDelaySeconds: 10
+            failureThreshold: 6
+          readinessProbe:
+            httpGet:
+              path: /readiness
+              port: 9099
+            periodSeconds: 10
           volumeMounts:
             - mountPath: /lib/modules
               name: lib-modules
@@ -162,15 +238,19 @@ spec:
             - mountPath: /var/run/calico
               name: var-run-calico
               readOnly: false
+        # This container installs the Calico CNI binaries
+        # and CNI network config file on each node.
         - name: install-cni
-          image: quay.io/calico/cni:v1.10.0
+          image: quay.io/calico/cni:v1.11.2
           command: ["/install-cni.sh"]
           env:
+            # The location of the Calico etcd cluster.
             - name: ETCD_ENDPOINTS
               valueFrom:
                 configMapKeyRef:
                   name: calico-config
                   key: etcd_endpoints
+            # The CNI network config to install on each node.
             - name: CNI_NETWORK_CONFIG
               valueFrom:
                 configMapKeyRef:
@@ -182,28 +262,102 @@ spec:
             - mountPath: /host/etc/cni/net.d
               name: cni-net-dir
       volumes:
+        # Used by calico/node.
         - name: lib-modules
           hostPath:
             path: /lib/modules
         - name: var-run-calico
           hostPath:
             path: /var/run/calico
+        # Used to install CNI.
         - name: cni-bin-dir
           hostPath:
             path: /opt/cni/bin
         - name: cni-net-dir
           hostPath:
             path: /etc/cni/net.d
+
 ---
+
+# This manifest deploys the Calico Kubernetes controllers.
+# See https://github.com/projectcalico/kube-controllers
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: calico-kube-controllers
+  namespace: kube-system
+  labels:
+    k8s-app: calico-kube-controllers
+spec:
+  # The controllers can only have a single active instance.
+  replicas: 1
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      name: calico-kube-controllers
+      namespace: kube-system
+      labels:
+        k8s-app: calico-kube-controllers
+      annotations:
+        # Mark this pod as a critical add-on; when enabled, the critical add-on scheduler
+        # reserves resources for critical add-on pods so that they can be rescheduled after
+        # a failure.  This annotation works in tandem with the toleration below.
+        scheduler.alpha.kubernetes.io/critical-pod: ''
+    spec:
+      # The controllers must run in the host network namespace so that
+      # it isn't governed by policy that would prevent it from working.
+      hostNetwork: true
+      tolerations:
+      # this taint is set by all kubelets running `--cloud-provider=external`
+      # so we should tolerate it to schedule the calico pods
+      - key: node.cloudprovider.kubernetes.io/uninitialized
+        value: "true"
+        effect: NoSchedule
+      - key: node-role.kubernetes.io/master
+        effect: NoSchedule
+      # Allow this pod to be rescheduled while the node is in "critical add-ons only" mode.
+      # This, along with the annotation above marks this pod as a critical add-on.
+      - key: CriticalAddonsOnly
+        operator: Exists
+      serviceAccountName: calico-kube-controllers
+      containers:
+        - name: calico-kube-controllers
+          image: quay.io/calico/kube-controllers:v1.0.2
+          env:
+            # The location of the Calico etcd cluster.
+            - name: ETCD_ENDPOINTS
+              valueFrom:
+                configMapKeyRef:
+                  name: calico-config
+                  key: etcd_endpoints
+            # The location of the Kubernetes API.  Use the default Kubernetes
+            # service for API access.
+            - name: K8S_API
+              value: "https://kubernetes.default:443"
+            # Choose which controllers to run.
+            - name: ENABLED_CONTROLLERS
+              value: policy,profile,workloadendpoint,node
+            # Since we're running in the host namespace and might not have KubeDNS
+            # access, configure the container's /etc/hosts to resolve
+            # kubernetes.default to the correct service clusterIP.
+            - name: CONFIGURE_ETC_HOSTS
+              value: "true"
+
+---
+
+# This deployment turns off the old "policy-controller". It should remain at 0 replicas, and then
+# be removed entirely once the new kube-controllers deployment has been deployed above.
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   name: calico-policy-controller
   namespace: kube-system
   labels:
-    k8s-app: calico-policy
+    k8s-app: calico-policy-controller
 spec:
-  replicas: 1
+  # Turn this deployment off in favor of the kube-controllers deployment above.
+  replicas: 0
   strategy:
     type: Recreate
   template:
@@ -212,26 +366,94 @@ spec:
       namespace: kube-system
       labels:
         k8s-app: calico-policy-controller
-      annotations:
-        scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
       hostNetwork: true
-      tolerations:
-      - key: node-role.kubernetes.io/master
-        effect: NoSchedule
-      - key: CriticalAddonsOnly
-        operator: Exists
-      serviceAccountName: calico-policy-controller
+      serviceAccountName: calico-kube-controllers
       containers:
         - name: calico-policy-controller
-          image: quay.io/calico/kube-policy-controller:v0.7.0
+          image: quay.io/calico/kube-controllers:v1.0.2
           env:
             - name: ETCD_ENDPOINTS
               valueFrom:
                 configMapKeyRef:
                   name: calico-config
                   key: etcd_endpoints
-            - name: K8S_API
-              value: "https://kubernetes.default:443"
-            - name: CONFIGURE_ETC_HOSTS
-              value: "true"
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: calico-cni-plugin
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: calico-cni-plugin
+subjects:
+- kind: ServiceAccount
+  name: calico-cni-plugin
+  namespace: kube-system
+
+---
+
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: calico-cni-plugin
+rules:
+  - apiGroups: [""]
+    resources:
+      - pods
+      - nodes
+    verbs:
+      - get
+
+---
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: calico-cni-plugin
+  namespace: kube-system
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: calico-kube-controllers
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: calico-kube-controllers
+subjects:
+- kind: ServiceAccount
+  name: calico-kube-controllers
+  namespace: kube-system
+
+---
+
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: calico-kube-controllers
+rules:
+  - apiGroups:
+    - ""
+    - extensions
+    resources:
+      - pods
+      - namespaces
+      - networkpolicies
+      - nodes
+    verbs:
+      - watch
+      - list
+
+---
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: calico-kube-controllers
+  namespace: kube-system

--- a/roles/cni/templates/flannel.yml.j2
+++ b/roles/cni/templates/flannel.yml.j2
@@ -1,4 +1,42 @@
 ---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: flannel
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - nodes
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - nodes/status
+    verbs:
+      - patch
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: flannel
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: flannel
+subjects:
+- kind: ServiceAccount
+  name: flannel
+  namespace: kube-system
+---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -24,7 +62,7 @@ data:
     }
   net-conf.json: |
     {
-      "Network": "{{ pod_network_cidr }}",
+      "Network": "10.244.0.0/16",
       "Backend": {
         "Type": "vxlan"
       }
@@ -53,15 +91,24 @@ spec:
         operator: Exists
         effect: NoSchedule
       serviceAccountName: flannel
+      initContainers:
+      - name: install-cni
+        image: quay.io/coreos/flannel:v0.9.1-amd64
+        command:
+        - cp
+        args:
+        - -f
+        - /etc/kube-flannel/cni-conf.json
+        - /etc/cni/net.d/10-flannel.conf
+        volumeMounts:
+        - name: cni
+          mountPath: /etc/cni/net.d
+        - name: flannel-cfg
+          mountPath: /etc/kube-flannel/
       containers:
       - name: kube-flannel
-        image: quay.io/coreos/flannel:v0.7.1-amd64
-        command: [
-          "/opt/bin/flanneld",
-          "--ip-masq",
-          "--kube-subnet-mgr",
-          "{{ cni_opts }}"
-        ]
+        image: quay.io/coreos/flannel:v0.9.1-amd64
+        command: [ "/opt/bin/flanneld", "--ip-masq", "--kube-subnet-mgr" ]
         securityContext:
           privileged: true
         env:
@@ -76,14 +123,6 @@ spec:
         volumeMounts:
         - name: run
           mountPath: /run
-        - name: flannel-cfg
-          mountPath: /etc/kube-flannel/
-      - name: install-cni
-        image: quay.io/coreos/flannel:v0.7.1-amd64
-        command: [ "/bin/sh", "-c", "set -e -x; cp -f /etc/kube-flannel/cni-conf.json /etc/cni/net.d/10-flannel.conf; while true; do sleep 3600; done" ]
-        volumeMounts:
-        - name: cni
-          mountPath: /etc/cni/net.d
         - name: flannel-cfg
           mountPath: /etc/kube-flannel/
       volumes:

--- a/roles/commons/os-checker/tasks/main.yml
+++ b/roles/commons/os-checker/tasks/main.yml
@@ -16,6 +16,13 @@
 - name: Set fact ansible_os_family var to Debian
   when:
     - ansible_os_family is not defined
+    - "'Debian' in distro.stdout"
+  set_fact:
+    ansible_os_family: Debian
+
+- name: Set fact ansible_os_family var to Debian
+  when:
+    - ansible_os_family is not defined
     - "'Ubuntu' in distro.stdout"
   set_fact:
     ansible_os_family: Debian

--- a/roles/kubernetes/master/tasks/main.yml
+++ b/roles/kubernetes/master/tasks/main.yml
@@ -12,6 +12,7 @@
                  --pod-network-cidr {{ pod_network_cidr }} \
                  --apiserver-advertise-address {{ groups['master'][0] }} \
                  --token {{ token }} \
+                 {{ kubeadm_opts }} \
                  {{ init_opts }}
   register: init_cluster
 

--- a/roles/kubernetes/master/tasks/main.yml
+++ b/roles/kubernetes/master/tasks/main.yml
@@ -10,7 +10,6 @@
     kubeadm init --service-cidr {{ service_cidr }} \
                  --kubernetes-version {{ kube_version }} \
                  --pod-network-cidr {{ pod_network_cidr }} \
-                 --apiserver-advertise-address {{ groups['master'][0] }} \
                  --token {{ token }} \
                  {{ kubeadm_opts }} \
                  {{ init_opts }}


### PR DESCRIPTION
See:
kubectl apply -f https://raw.githubusercontent.com/coreos/flannel/v0.9.1/Documentation/kube-flannel.yml
kubectl apply -f https://docs.projectcalico.org/v3.0/getting-started/kubernetes/installation/hosted/kubeadm/1.7/calico.yaml

I remove RBAC to instead include the official all-in-one file that's
included on the kubeadm documentation: https://kubernetes.io/docs/setup/independent/create-cluster-kubeadm/<Paste>

I also modify the "os-checker" to allow the ability to use Debian instead of Ubuntu (Debian 9 works perfect by the way with these Ansible scripts)