### PR TITLE
Use the actual user not root

### DIFF
--- a/roles/kubernetes/master/tasks/main.yml
+++ b/roles/kubernetes/master/tasks/main.yml
@@ -16,15 +16,15 @@
   register: init_cluster
 
 - name: Create Kubernetes config directory
-  file: path=/root/.kube/ state=directory
+  file: path=/{{ ansible_user_id }}/.kube/ state=directory
 
 - name: Copy admin.conf to Home directory
   when: init_cluster
   copy:
     src: "{{ kubeadmin_config }}"
-    dest: "/root/.kube/config"
-    owner: root
-    group: root
+    dest: "/{{ ansible_user_id }}/.kube/config"
+    owner: {{ ansible_user_id }}
+    group: {{ ansible_user_id }}
     mode: 0755
     remote_src: True
 


### PR DESCRIPTION
I'm deploying this ansible script to users which are named "k8s". At the
moment, the ansible script assumes that you are root which is not always
the case. This copies the actual configuration file to the user it's
being deployed to rather than the root user.