### PR TITLE
Fix bug regarding getting user home directory

### DIFF
--- a/roles/kubernetes/master/tasks/main.yml
+++ b/roles/kubernetes/master/tasks/main.yml
@@ -16,15 +16,20 @@
   register: init_cluster
 
 - name: Create Kubernetes config directory
-  file: path=/{{ ansible_user_id }}/.kube/ state=directory
+  become: false
+  file: path="~/.kube/" state=directory
+
+- name: Change permissions of .kube/config
+  file: path=/etc/kubernetes/admin.conf mode=0775
 
 - name: Copy admin.conf to Home directory
   when: init_cluster
+  become: false
   copy:
     src: "{{ kubeadmin_config }}"
-    dest: "/{{ ansible_user_id }}/.kube/config"
-    owner: {{ ansible_user_id }}
-    group: {{ ansible_user_id }}
+    dest: "~/.kube/config"
+    owner: "{{ ansible_user }}"
+    group: "{{ ansible_user }}"
     mode: 0755
     remote_src: True
 

--- a/site.yaml
+++ b/site.yaml
@@ -1,25 +1,25 @@
 ---
 
 - hosts: kube-cluster
-  gather_facts: no
+  gather_facts: yes
   become: yes
   roles:
     - { role: docker, tags: docker }
 
 - hosts: master
-  gather_facts: no
+  gather_facts: yes
   become: yes
   roles:
     - { role: kubernetes/master, tags: master }
 
 - hosts: node
-  gather_facts: no
+  gather_facts: yes
   become: yes
   roles:
     - { role: kubernetes/node, tags: node }
 
 - hosts: master
-  gather_facts: no
+  gather_facts: yes
   become: yes
   roles:
     - { role: cni, tags: cni }


### PR DESCRIPTION
Since we "become:true", we will *always* be root when deploying. This
disables it so we can gather the correct user home directory.

