### PR TITLE
Add apt-transport-https Debian

### DIFF
--- a/roles/docker/tasks/pkg.yml
+++ b/roles/docker/tasks/pkg.yml
@@ -1,4 +1,9 @@
 ---
+- name: Install apt-transport-https
+  when: ansible_os_family == "Debian"
+  apt:
+    name: "apt-transport-https"
+    state: present
 
 - name: Add Docker APT GPG key
   when: ansible_os_family == "Debian"


### PR DESCRIPTION
Add a prerequisite task on Debian. Installs apt-transport-https as it is required for https:// docker repositories in some cases (otherwise failing)