### PR TITLE
Fixes issue with not resetting

### DIFF
--- a/roles/kubernetes/master/tasks/main.yml
+++ b/roles/kubernetes/master/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: Reset Kubernetes component
-  shell: "kubeadm reset"
+  shell: "kubeadm reset --force"
   register: reset_cluster
 
 - name: Init Kubernetes cluster

--- a/roles/kubernetes/node/tasks/main.yml
+++ b/roles/kubernetes/node/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: Reset Kubernetes component
-  shell: "kubeadm reset"
+  shell: "kubeadm reset --force"
   register: reset_cluster
 
 - name: Join to Kubernetes cluster


### PR DESCRIPTION
This adds --force to the `kubeadm reset` command due to not being able
to reset without confirmation (previous kubeadm releases did not have
this confirmation screen).