### PR TITLE
Fix playbook reset-site

### DIFF
--- a/reset-site.yaml
+++ b/reset-site.yaml
@@ -5,13 +5,15 @@
   become: yes
   tasks:
     - name: Reset Kubernetes component
-      shell: "kubeadm reset"
+      shell: "kubeadm reset --force"
       ignore_errors: True
 
     - name: Delete flannel.1 interface
       command: ip link delete flannel.1
+      when: network == "flannel"
       ignore_errors: True
 
     - name: Delete cni0 interface
       command: ip link delete cni0
+      when: network == "flannel"
       ignore_errors: True


### PR DESCRIPTION
Hi,

Just a little fix on the reset playbook :
* Add flag `--force` on the command `kubeadm reset`,
* Add a condition on the deletion of the flannel network.

Thank for your work 👍 