### PR TITLE
Change --skip-preflight-checks to --ignore-preflight-errors

### DIFF
--- a/roles/kubernetes/node/tasks/main.yml
+++ b/roles/kubernetes/node/tasks/main.yml
@@ -7,7 +7,7 @@
 - name: Join to Kubernetes cluster
   when: reset_cluster|succeeded
   shell: |
-    kubeadm join --skip-preflight-checks \
+    kubeadm join --ignore-preflight-errors \
                  --token {{ token }} \
                  {{ groups['master'][0] }}:6443 \
                  --discovery-token-unsafe-skip-ca-verification


### PR DESCRIPTION
In January 2018, the parameter was changed.

See: https://github.com/kubernetes/minikube/issues/2703

Removes the error caused by:

```
                 Auditing=true|false (ALPHA - default=false)\n                                                      CoreDNS=true|false (default=true)\n                                                      DynamicKubeletConfig=true|false (BETA - default=false)\n  -h, --help                                          help for join\n      --ignore-preflight-errors str
ings               A list of checks whose errors will be shown as warnings. Example: 'IsPrivilegedUser,Swap'. Value 'all' ignores errors from all checks.\n      --node-name string                              Specify the node name.\n      --tls-bootstrap-token string                    A token used for TLS bootstrapping.\n      --token string
             Use this token for both discovery-token and tls-bootstrap-token.\n\nGlobal Flags:\n      --rootfs string   [EXPERIMENTAL] The path to the 'real' host root filesystem.\n  -v, --v Level         log level for V logs\n\nerror: unknown flag: --skip-preflight-errors", "stderr_lines": ["Error: unknown flag: --skip-preflight-errors", "Usage:", "  kubeadm joi
n [flags]", "", "Flags:", "      --apiserver-advertise-address string            If the node should host a new control plane instance, the IP address the API Server will advertise it's listening on.", "      --apiserver-bind-port int32                     If the node should host a new control plane instance, the port for the API Server to bind to. (default 6443)"
, "      --config string                                 Path to kubeadm config file.", "      --cri-socket string                             Specify the CRI socket to connect to. (default \"/var/run/dockershim.sock\")", "      --discovery-file string                         A file or url from which to load cluster information.", "      --discovery-token string
                       A token used to validate cluster information fetched from the api server.", "      --discovery-token-ca-cert-hash strings          For token-based discovery, validate that the root CA public key matches this hash (format: \"<type>:<value>\").", "      --discovery-token-unsafe-skip-ca-verification   For token-based discovery, allow joining w
ithout --discovery-token-ca-cert-hash pinning.", "      --experimental-control-plane                    Create a new control plane instance on this node", "      --feature-gates string                          A set of key=value pairs that describe feature gates for various features. Options are:", "                                                      Auditing=t
rue|false (ALPHA - default=false)", "                                                      CoreDNS=true|false (default=true)", "                                                      DynamicKubeletConfig=true|false (BETA - default=false)", "  -h, --help                                          help for join", "      --ignore-preflight-errors strings
A list of checks whose errors will be shown as warnings. Example: 'IsPrivilegedUser,Swap'. Value 'all' ignores errors from all checks.", "      --node-name string                              Specify the node name.", "      --tls-bootstrap-token string                    A token used for TLS bootstrapping.", "      --token string
Use this token for both discovery-token and tls-bootstrap-token.", "", "Global Flags:", "      --rootfs string   [EXPERIMENTAL] The path to the 'real' host root filesystem.", "  -v, --v Level         log level for V logs", "", "error: unknown flag: --skip-preflight-errors"], "stdout": "", "stdout_lines": []}
        to retry, use: --limit @/home/wikus/seafile/files/dev/linux/ansible-playbooks/kubeadm-ansible/site.retry
```

This PR changes is to the new parameter