### PR TITLE
Upgrade to 1.12.1, remove preflight checks

### DIFF
--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -2,7 +2,7 @@
 # ansible_user: root
 
 # Kubernetes
-kube_version: v1.11.1
+kube_version: v1.12.1
 token: b0f7b8.8d1767876297d85c
 
 # 1.8.x feature: --feature-gates SelfHosting=true

--- a/roles/kubernetes/node/tasks/main.yml
+++ b/roles/kubernetes/node/tasks/main.yml
@@ -7,10 +7,9 @@
 - name: Join to Kubernetes cluster
   when: reset_cluster|succeeded
   shell: |
-    kubeadm join --skip-preflight-checks \
-                 --token {{ token }} \
-                 {{ groups['master'][0] }}:6443 \
-                 --discovery-token-unsafe-skip-ca-verification
+    kubeadm join --token {{ token }} \
+                 --discovery-token-unsafe-skip-ca-verification \
+                 {{ groups['master'][0] }}:6443
   register: join_cluster
 
 - name: Enable and restart kubelet engine


### PR DESCRIPTION
Removes preflight checks, this is required in order to setup TLS
correctly or else the below error occurs:

```sh
fatal: [192.168.1.115]: FAILED! => {"changed": true, "cmd": "kubeadm join --ignore-preflight-errors --token bvj0xj.21nh46utwlcgt3vd 192.168.1.124:6443 --discovery-token-unsafe-skip-ca-verification", "delta": "0:00:00.030162", "end": "2018-10-17 15:02:51.657645", "msg": "non-zero return code", "rc": 3, "start": "2018-10-17 15:02:51.627483", "stderr": "[tlsBootstra
pToken: Invalid value: \"\": the bootstrap token is invalid, discovery: Invalid value: \"\": discoveryToken or discoveryFile must be set, discoveryTokenAPIServers: Invalid value: \"bvj0xj.21nh46utwlcgt3vd\": address bvj0xj.21nh46utwlcgt3vd: missing port in address]", "stderr_lines": ["[tlsBootstrapToken: Invalid value: \"\": the bootstrap token is invalid, discov
ery: Invalid value: \"\": discoveryToken or discoveryFile must be set, discoveryTokenAPIServers: Invalid value: \"bvj0xj.21nh46utwlcgt3vd\": address bvj0xj.21nh46utwlcgt3vd: missing port in address]"], "stdout": "[validation] WARNING: kubeadm doesn't fully support multiple API Servers yet", "stdout_lines": ["[validation] WARNING: kubeadm doesn't fully support mul
tiple API Servers yet"]}
fatal: [192.168.1.123]: FAILED! => {"changed": true, "cmd": "kubeadm join --ignore-preflight-errors --token bvj0xj.21nh46utwlcgt3vd 192.168.1.124:6443 --discovery-token-unsafe-skip-ca-verification", "delta": "0:00:00.021953", "end": "2018-10-17 15:02:51.697518", "msg": "non-zero return code", "rc": 3, "start": "2018-10-17 15:02:51.675565", "stderr": "[tlsBootstra
pToken: Invalid value: \"\": the bootstrap token is invalid, discovery: Invalid value: \"\": discoveryToken or discoveryFile must be set, discoveryTokenAPIServers: Invalid value: \"bvj0xj.21nh46utwlcgt3vd\": address bvj0xj.21nh46utwlcgt3vd: missing port in address]", "stderr_lines": ["[tlsBootstrapToken: Invalid value: \"\": the bootstrap token is invalid, discov
ery: Invalid value: \"\": discoveryToken or discoveryFile must be set, discoveryTokenAPIServers: Invalid value: \"bvj0xj.21nh46utwlcgt3vd\": address bvj0xj.21nh46utwlcgt3vd: missing port in address]"], "stdout": "[validation] WARNING: kubeadm doesn't fully support multiple API Servers yet", "stdout_lines": ["[validation] WARNING: kubeadm doesn't fully support mul
tiple API Servers yet"]}
```

We also upgrade to 1.12.1