### PR TITLE
Upgrade flannel to 0.10.0

### DIFF
--- a/roles/cni/templates/flannel.yml.j2
+++ b/roles/cni/templates/flannel.yml.j2
@@ -93,7 +93,7 @@ spec:
       serviceAccountName: flannel
       initContainers:
       - name: install-cni
-        image: quay.io/coreos/flannel:v0.9.1-amd64
+        image: quay.io/coreos/flannel:v0.10.0-amd64
         command:
         - cp
         args:
@@ -107,7 +107,7 @@ spec:
           mountPath: /etc/kube-flannel/
       containers:
       - name: kube-flannel
-        image: quay.io/coreos/flannel:v0.9.1-amd64
+        image: quay.io/coreos/flannel:v0.10.0-amd64
         command:
           - /opt/bin/flanneld
           - --ip-masq


### PR DESCRIPTION
NodePort does not work on Docker 1.13+ with Flannel 0.9.1

Flannel must be upgraded to 0.10.0. This is because iptables was changed
from DROP to FORWARD.

See: https://github.com/kubernetes/kubernetes/issues/42413

as well as:
https://github.com/coreos/flannel/blob/master/Documentation/troubleshooting.md
(connectivity message)