### PR TITLE
Upgrade to 1.13 due to CVE

### DIFF
--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -2,7 +2,7 @@
 # ansible_user: root
 
 # Kubernetes
-kube_version: v1.12.2
+kube_version: v1.13.0
 token: b0f7b8.8d1767876297d85c
 
 # 1.8.x feature: --feature-gates SelfHosting=true

--- a/roles/commons/pre-install/tasks/pkg.yml
+++ b/roles/commons/pre-install/tasks/pkg.yml
@@ -28,9 +28,11 @@
   yum:
     name: "{{ pkgs }}"
     update_cache: yes
+    state: latest
 
 - name: Install kubernetes packages (Debian/Ubuntu)
   when: ansible_os_family == "Debian"
   apt:
     name: "{{ pkgs }}"
     update_cache: yes
+    state: latest


### PR DESCRIPTION
Upgrades to 1.13 due to CVE and makes sure that when site.yaml is
re-ran, we upgrade the packages.