### PR TITLE
Use the master's default ipv4 address, not `ansible_host`

### DIFF
--- a/group_vars/kube-cluster.yml
+++ b/group_vars/kube-cluster.yml
@@ -1,3 +1,3 @@
 ---
 
-master_ip: "{{ hostvars[groups['master'][0]]['ansible_host'] | default(groups['master'][0]) }}"
+master_ip: "{{ hostvars[groups['master'][0]]['ansible_default_ipv4'].address | default(groups['master'][0]) }}"


### PR DESCRIPTION
Inventory files that have FQDNs for the hosts of a cluster instead of
raw IPs would fail.

        fatal: [osctrl-bgcloudv3-1.ece.comcast.net]: FAILED! => {"changed": true, "cmd": "kubeadm init --service-cidr 10.96.0.0/12 --kubernetes-version v1.13.0 --pod-network-cidr 10.244.0.0/16 --token <token> --apiserver-advertise-address osctrl-bgcloudv3-1.ece.comcast.net  ", "delta": "0:00:00.025122", "end": "2019-03-06 15:35:58.549072", "msg": "non-zero return code", "rc": 1, "start": "2019-03-06 15:35:58.523950", "stderr": "couldn't use \"osctrl-bgcloudv3-1.ece.comcast.net\" as \"apiserver-advertise-address\", must be ipv4 or ipv6 address", "stderr_lines": ["couldn't use \"osctrl-bgcloudv3-1.ece.comcast.net\" as \"apiserver-advertise-address\", must be ipv4 or ipv6 address"], "stdout": "", "stdout_lines": []}