### PR TITLE
Make calico's etcd service configurable

### DIFF
--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -16,6 +16,8 @@ kubeadm_opts: ""
 service_cidr: "10.96.0.0/12"
 pod_network_cidr: "10.244.0.0/16"
 
+calico_etcd_service: "10.96.232.136"
+
 # Network implementation('flannel', 'calico')
 network: calico
 

--- a/roles/cni/templates/calico-etcd.yml.j2
+++ b/roles/cni/templates/calico-etcd.yml.j2
@@ -78,6 +78,6 @@ spec:
     k8s-app: calico-etcd
   # This ClusterIP needs to be known in advance, since we cannot rely
   # on DNS to get access to etcd.
-  clusterIP: 10.96.232.136
+  clusterIP: {{ calico_etcd_service }}
   ports:
     - port: 6666

--- a/roles/cni/templates/calico.yml.j2
+++ b/roles/cni/templates/calico.yml.j2
@@ -13,7 +13,7 @@ metadata:
   namespace: kube-system
 data:
   # Configure this with the location of your etcd cluster.
-  etcd_endpoints: "http://10.96.232.136:6666"
+  etcd_endpoints: "http://{{ calico_etcd_service }}:6666"
 
   # If you're using TLS enabled etcd uncomment the following.
   # You must also populate the Secret below with these files.
@@ -76,7 +76,7 @@ spec:
     k8s-app: calico-etcd
   # This ClusterIP needs to be known in advance, since we cannot rely
   # on DNS to get access to etcd.
-  clusterIP: 10.96.232.136
+  clusterIP: {{ calico_etcd_service }}
   ports:
     - port: 6666
 


### PR DESCRIPTION
If you pass in a different `service_cidr` value than the default, you need to go and update all the Calico YAMLs with this new address.