### PR TITLE
fix(common/pre-install): debian/ubuntu uses "present" for package state

### DIFF
--- a/roles/commons/pre-install/tasks/pkg.yml
+++ b/roles/commons/pre-install/tasks/pkg.yml
@@ -36,5 +36,5 @@
   apt:
     name: "{{ pkgs }}"
     update_cache: yes
-    state: installed
+    state: present
   with_items: "{{ pkgs }}"


### PR DESCRIPTION
### desc
when play `site.yaml` I encountered with the following error:
```
TASK [commons/pre-install : Install kubernetes packages (Debian/Ubuntu)] *******************************************************************************************************************************************
Monday 30 December 2019  17:48:41 +0000 (0:00:00.293)       0:02:13.570 *******
failed: [master-main] (item=kubelet) => {"ansible_loop_var": "item", "changed": false, "item": "kubelet", "msg": "value of state must be one of: absent, build-dep, fixed, latest, present, got: installed"}
failed: [master-main] (item=kubeadm) => {"ansible_loop_var": "item", "changed": false, "item": "kubeadm", "msg": "value of state must be one of: absent, build-dep, fixed, latest, present, got: installed"}
failed: [master-main] (item=kubectl) => {"ansible_loop_var": "item", "changed": false, "item": "kubectl", "msg": "value of state must be one of: absent, build-dep, fixed, latest, present, got: installed"}
```
which lead to a fatal result.

### reference
reference: https://docs.ansible.com/ansible/2.9/modules/apt_module.html#status

