### PR TITLE
Updates the version + adds no_proxy

### DIFF
--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -2,7 +2,7 @@
 # ansible_user: root
 
 # Kubernetes
-kube_version: v1.16.3
+kube_version: v1.19.2
 token: b0f7b8.8d1767876297d85c
 
 # 1.8.x feature: --feature-gates SelfHosting=true

--- a/roles/kubernetes/master/tasks/init.yml
+++ b/roles/kubernetes/master/tasks/init.yml
@@ -15,6 +15,9 @@
                  {{ kubeadm_opts }} \
                  {{ init_opts }}
   register: init_cluster
+  # See: https://github.com/jetstack/cert-manager/issues/2640 with using kubeadm + calico + cert-manager
+  environment:
+    no_proxy: "$no_proxy,.svc,.svc.cluster.local"
 
 - name: Create Kubernetes config directory
   file:

--- a/roles/kubernetes/node/tasks/join.yml
+++ b/roles/kubernetes/node/tasks/join.yml
@@ -11,5 +11,8 @@
                 --discovery-token-unsafe-skip-ca-verification \
                 {{ master_ip }}:6443
   register: join_cluster
+  # See: https://github.com/jetstack/cert-manager/issues/2640 with using kubeadm + calico + cert-manager
+  environment:
+    no_proxy: "$no_proxy,.svc,.svc.cluster.local"
   notify:
     - Recreate kube-dns


### PR DESCRIPTION
Multiple issues being encountered when running cert-manager.

We also haven't updated the version in a while since a new version of
k8s and kubeadm has already gone out.

Signed-off-by: Charlie Drage <charlie@charliedrage.com>