### PR TITLE
Add container_runtime variables & additional scripts for deleting CNI

### DIFF
--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -44,3 +44,5 @@ additional_features:
 # temporary directory used by additional features
 tmp_dir: /tmp/kubeadm-ansible-files
 
+# Container runtimes ('containerd', 'crio')
+container_runtime: containerd

--- a/reset-site.yaml
+++ b/reset-site.yaml
@@ -5,7 +5,7 @@
   become: yes
   tasks:
     - name: Reset Kubernetes component
-      shell: "kubeadm reset --force"
+      shell: "kubeadm reset --force --cri-socket=/var/run/{{ container_runtime }}/{{ container_runtime }}.sock"
       ignore_errors: True
 
     - name: Delete flannel.1 interface
@@ -17,3 +17,35 @@
       command: ip link delete cni0
       when: network == "flannel"
       ignore_errors: True
+
+    - name: Delete tunl0 interface
+      command: modprobe -r ipip
+      when: network == "calico"
+      ignore_errors: True
+
+    - name: Find network interfaces for Kubernetes
+      shell: "ip addr | grep {{ item }}"
+      with_items:
+        - "docker0"
+        - "flannel.1"
+        - "cni0"
+        - "tunl0"
+      register: find_eths
+      ignore_errors: True
+
+    - name: Delete network interfaces for Kubernetes
+      when: item.stdout != ''
+      shell: "ip link delete {{ item.item }}"
+      with_items: "{{ find_eths['results'] }}"
+      ignore_errors: True
+
+    - name: Find blackhole route rule
+      shell: "ip route | awk '/blackhole/ {print $2}'"
+      register: find_blackhole
+      ignore_errors: True
+
+    - name: Delete blackhole route rule
+      when: find_blackhole.stdout != ''
+      shell: "ip route del {{ find_blackhole.stdout }}"
+      ignore_errors: True
+

--- a/roles/kubernetes/master/tasks/init.yml
+++ b/roles/kubernetes/master/tasks/init.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: Reset Kubernetes component
-  shell: "kubeadm reset --force"
+  shell: "kubeadm reset --force --cri-socket=/var/run/{{ container_runtime }}/{{ container_runtime }}.sock"
   register: reset_cluster
 
 - name: Init Kubernetes cluster
@@ -12,6 +12,7 @@
                  --pod-network-cidr {{ pod_network_cidr }} \
                  --token {{ token }} \
                  --apiserver-advertise-address {{ master_ip }} \
+                 --cri-socket=/var/run/{{ container_runtime }}/{{ container_runtime }}.sock \
                  {{ kubeadm_opts }} \
                  {{ init_opts }}
   register: init_cluster

--- a/roles/kubernetes/node/tasks/join.yml
+++ b/roles/kubernetes/node/tasks/join.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: Reset Kubernetes component
-  shell: "kubeadm reset --force"
+  shell: "kubeadm reset --force --cri-socket=/var/run/{{ container_runtime }}/{{ container_runtime }}.sock"
   register: reset_cluster
 
 - name: Join to Kubernetes cluster
@@ -9,6 +9,7 @@
   shell: |
     kubeadm join --token {{ token }} \
                 --discovery-token-unsafe-skip-ca-verification \
+                --cri-socket=/var/run/{{ container_runtime }}/{{ container_runtime }}.sock \
                 {{ master_ip }}:6443
   register: join_cluster
   # See: https://github.com/jetstack/cert-manager/issues/2640 with using kubeadm + calico + cert-manager


### PR DESCRIPTION
* Add `container_runtime` into `group_vars/all.yml` for compatibility of  `containerd` and `cri-o`
* Add additional scripts for deleting calico network interfaces.
  * Refer to @kairen's [kube-ansible repo](https://github.com/kairen/kube-ansible/blob/master/roles/cluster-reset/tasks/reset-k8s.yml)