### PR TITLE
fix: install helm script fails

### DIFF
--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -46,3 +46,6 @@ tmp_dir: /tmp/kubeadm-ansible-files
 
 # Container runtimes ('containerd', 'crio')
 container_runtime: containerd
+
+# helm helm version
+helm_version: "v2.17.0"

--- a/roles/helm/tasks/main.yml
+++ b/roles/helm/tasks/main.yml
@@ -19,8 +19,10 @@
         url: https://raw.githubusercontent.com/helm/helm/master/scripts/get
         dest: "{{ tmp_dir }}/get_helm.sh"
         mode: 0755
-  
+
     - name: "Run the installer"
+      environment:
+          DESIRED_VERSION: "{{ helm_version }}"
       shell: "{{ tmp_dir }}/get_helm.sh"
 
   when: helm_exists.rc > 0


### PR DESCRIPTION
The SHA1 verification of the helm binary downloaded via the script at https://raw.githubusercontent.com/helm/helm/master/scripts/get fails with sha mismatch.